### PR TITLE
config: mark unsupported fw3 options correctly

### DIFF
--- a/root/etc/config/firewall
+++ b/root/etc/config/firewall
@@ -3,8 +3,6 @@ config defaults
 	option input		REJECT
 	option output		ACCEPT
 	option forward		REJECT
-# Uncomment this line to disable ipv6 rules
-#	option disable_ipv6	1
 
 config zone
 	option name		lan

--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -1959,12 +1959,12 @@ return {
 			synflood_rate: [ "limit", "25/second" ],
 			synflood_burst: [ "int", "50" ],
 
-			tcp_syncookies: [ "bool", "1" ],
-			tcp_ecn: [ "int" ],
-			tcp_window_scaling: [ "bool", "1" ],
+			tcp_syncookies: [ "bool", null, UNSUPPORTED ],
+			tcp_ecn: [ "int", null, UNSUPPORTED ],
+			tcp_window_scaling: [ "bool", null, UNSUPPORTED ],
 
-			accept_redirects: [ "bool" ],
-			accept_source_route: [ "bool" ],
+			accept_redirects: [ "bool", null, UNSUPPORTED ],
+			accept_source_route: [ "bool", null, UNSUPPORTED ],
 
 			auto_helper: [ "bool", "1" ],
 			custom_chains: [ "bool", null, UNSUPPORTED ],


### PR DESCRIPTION
- mark sysctl-based fw3 options UNSUPPORTED, emitting warning
- remove notion of unsupported option from default config file

No change in ruleset logic.