### PR TITLE
ruleset: skip _iifname match for !tcp in mss fix

### DIFF
--- a/root/usr/share/firewall4/templates/zone-mssfix.uc
+++ b/root/usr/share/firewall4/templates/zone-mssfix.uc
@@ -1,5 +1,6 @@
 {%+ if (rule.family): -%}
 	meta nfproto {{ fw4.nfproto(rule.family) }} {%+ endif -%}
+	meta l4proto tcp {%+ -%}
 {%+ include("zone-match.uc", { egress, rule }) -%}
 tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu {%+ if (zone.log & 2): -%}
 	log prefix "MSSFIX {{ zone.name }} out: " {%+ endif -%}

--- a/tests/01_configuration/01_ruleset
+++ b/tests/01_configuration/01_ruleset
@@ -269,7 +269,7 @@ table inet fw4 {
 
 	chain mangle_postrouting {
 		type filter hook postrouting priority mangle; policy accept;
-		oifname "pppoe-wan" tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 egress MTU fixing"
+		meta l4proto tcp oifname "pppoe-wan" tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 egress MTU fixing"
 	}
 
 	chain mangle_input {
@@ -282,7 +282,7 @@ table inet fw4 {
 
 	chain mangle_forward {
 		type filter hook forward priority mangle; policy accept;
-		iifname "pppoe-wan" tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 ingress MTU fixing"
+		meta l4proto tcp iifname "pppoe-wan" tcp flags syn / syn,fin,rst tcp option maxseg size set rt mtu comment "!fw4: Zone wan IPv4/IPv6 ingress MTU fixing"
 	}
 }
 -- End --


### PR DESCRIPTION
Add explicit l4proto match before _ifname to avoid burning cycles for other protocols, eliminating measurable (iperf3) udp re-ordering Displayed back rules show pessimal combo even new one is loaded.