### PR TITLE
Do not emit helper jump without helper modules

### DIFF
--- a/root/usr/share/ucode/fw4.uc
+++ b/root/usr/share/ucode/fw4.uc
@@ -2186,7 +2186,7 @@ return {
 			zone.dflags.snat = true;
 
 		if ((zone.auto_helper && !(zone.masq || zone.masq6)) || length(zone.helper)) {
-			zone.dflags.helper = true;
+			zone.dflags.helper = false;
 
 			for (let helper in (length(zone.helper) ? zone.helper : this.state.helpers)) {
 				if (!helper.available)
@@ -2203,6 +2203,7 @@ return {
 						target: "helper",
 						set_helper: helper
 					});
+					zone.dflags.helper = true;
 				}
 			}
 		}

--- a/tests/02_zones/01_policies
+++ b/tests/02_zones/01_policies
@@ -123,9 +123,6 @@ table inet fw4 {
 
 	chain prerouting {
 		type filter hook prerouting priority filter; policy accept;
-		iifname "zone1" jump helper_test1 comment "!fw4: Handle test1 IPv4/IPv6 helper assignment"
-		iifname "zone2" jump helper_test2 comment "!fw4: Handle test2 IPv4/IPv6 helper assignment"
-		iifname "zone3" jump helper_test3 comment "!fw4: Handle test3 IPv4/IPv6 helper assignment"
 	}
 
 	chain handle_reject {
@@ -143,9 +140,6 @@ table inet fw4 {
 
 	chain forward_test1 {
 		jump accept_to_test1
-	}
-
-	chain helper_test1 {
 	}
 
 	chain accept_from_test1 {
@@ -168,9 +162,6 @@ table inet fw4 {
 		jump drop_to_test2
 	}
 
-	chain helper_test2 {
-	}
-
 	chain drop_from_test2 {
 		iifname "zone2" counter drop comment "!fw4: drop test2 IPv4/IPv6 traffic"
 	}
@@ -189,9 +180,6 @@ table inet fw4 {
 
 	chain forward_test3 {
 		jump reject_to_test3
-	}
-
-	chain helper_test3 {
 	}
 
 	chain reject_from_test3 {

--- a/tests/02_zones/04_wildcard_devices
+++ b/tests/02_zones/04_wildcard_devices
@@ -168,14 +168,6 @@ table inet fw4 {
 
 	chain prerouting {
 		type filter hook prerouting priority filter; policy accept;
-		iifname "/never/" jump helper_test2 comment "!fw4: Handle test2 IPv4/IPv6 helper assignment"
-		iifname "test*" jump helper_test3 comment "!fw4: Handle test3 IPv4/IPv6 helper assignment"
-		iifname "foo*" jump helper_test4 comment "!fw4: Handle test4 IPv4/IPv6 helper assignment"
-		iifname "bar*" jump helper_test4 comment "!fw4: Handle test4 IPv4/IPv6 helper assignment"
-		iifname { "test1", "test2" } jump helper_test4 comment "!fw4: Handle test4 IPv4/IPv6 helper assignment"
-		iifname "foo*" iifname != { "test3", "test4" } iifname != "baz*" iifname != "qrx*" jump helper_test5 comment "!fw4: Handle test5 IPv4/IPv6 helper assignment"
-		iifname "bar*" iifname != { "test3", "test4" } iifname != "baz*" iifname != "qrx*" jump helper_test5 comment "!fw4: Handle test5 IPv4/IPv6 helper assignment"
-		iifname { "test1", "test2" } iifname != { "test3", "test4" } iifname != "baz*" iifname != "qrx*" jump helper_test5 comment "!fw4: Handle test5 IPv4/IPv6 helper assignment"
 	}
 
 	chain handle_reject {
@@ -193,9 +185,6 @@ table inet fw4 {
 
 	chain forward_test1 {
 		jump drop_to_test1
-	}
-
-	chain helper_test1 {
 	}
 
 	chain drop_from_test1 {
@@ -218,9 +207,6 @@ table inet fw4 {
 		jump drop_to_test2
 	}
 
-	chain helper_test2 {
-	}
-
 	chain drop_from_test2 {
 		iifname "/never/" counter drop comment "!fw4: drop test2 IPv4/IPv6 traffic"
 	}
@@ -241,9 +227,6 @@ table inet fw4 {
 		jump drop_to_test3
 	}
 
-	chain helper_test3 {
-	}
-
 	chain drop_from_test3 {
 		iifname "test*" counter drop comment "!fw4: drop test3 IPv4/IPv6 traffic"
 	}
@@ -262,9 +245,6 @@ table inet fw4 {
 
 	chain forward_test4 {
 		jump drop_to_test4
-	}
-
-	chain helper_test4 {
 	}
 
 	chain drop_from_test4 {
@@ -289,9 +269,6 @@ table inet fw4 {
 
 	chain forward_test5 {
 		jump drop_to_test5
-	}
-
-	chain helper_test5 {
 	}
 
 	chain drop_from_test5 {

--- a/tests/02_zones/05_subnet_mask_matches
+++ b/tests/02_zones/05_subnet_mask_matches
@@ -112,9 +112,6 @@ table inet fw4 {
 
 	chain prerouting {
 		type filter hook prerouting priority filter; policy accept;
-		meta nfproto ipv6 ip6 saddr != { ::7, ::8 } ip6 saddr & ::ffff == ::1 ip6 saddr & ::ffff != ::5 ip6 saddr & ::ffff != ::6 jump helper_test2 comment "!fw4: Handle test2 IPv6 helper assignment"
-		meta nfproto ipv6 ip6 saddr != { ::7, ::8 } ip6 saddr & ::ffff == ::2 ip6 saddr & ::ffff != ::5 ip6 saddr & ::ffff != ::6 jump helper_test2 comment "!fw4: Handle test2 IPv6 helper assignment"
-		meta nfproto ipv6 ip6 saddr { ::3, ::4 } ip6 saddr != { ::7, ::8 } ip6 saddr & ::ffff != ::5 ip6 saddr & ::ffff != ::6 jump helper_test2 comment "!fw4: Handle test2 IPv6 helper assignment"
 	}
 
 	chain handle_reject {
@@ -132,9 +129,6 @@ table inet fw4 {
 
 	chain forward_test1 {
 		jump drop_to_test1
-	}
-
-	chain helper_test1 {
 	}
 
 	chain drop_from_test1 {
@@ -155,9 +149,6 @@ table inet fw4 {
 
 	chain forward_test2 {
 		jump drop_to_test2
-	}
-
-	chain helper_test2 {
 	}
 
 	chain drop_from_test2 {

--- a/tests/03_rules/03_constraints
+++ b/tests/03_rules/03_constraints
@@ -147,9 +147,6 @@ table inet fw4 {
 		jump drop_to_lan
 	}
 
-	chain helper_lan {
-	}
-
 	chain drop_from_lan {
 	}
 

--- a/tests/03_rules/05_mangle
+++ b/tests/03_rules/05_mangle
@@ -203,8 +203,6 @@ table inet fw4 {
 
 	chain prerouting {
 		type filter hook prerouting priority filter; policy accept;
-		iifname { "eth0", "eth1" } jump helper_lan comment "!fw4: Handle lan IPv4/IPv6 helper assignment"
-		iifname { "eth2", "eth3" } jump helper_wan comment "!fw4: Handle wan IPv4/IPv6 helper assignment"
 	}
 
 	chain handle_reject {
@@ -222,9 +220,6 @@ table inet fw4 {
 
 	chain forward_lan {
 		jump drop_to_lan
-	}
-
-	chain helper_lan {
 	}
 
 	chain drop_from_lan {
@@ -245,9 +240,6 @@ table inet fw4 {
 
 	chain forward_wan {
 		jump drop_to_wan
-	}
-
-	chain helper_wan {
 	}
 
 	chain drop_from_wan {

--- a/tests/03_rules/11_log
+++ b/tests/03_rules/11_log
@@ -157,9 +157,6 @@ table inet fw4 {
 		jump drop_to_wan
 	}
 
-	chain helper_wan {
-	}
-
 	chain drop_from_wan {
 	}
 


### PR DESCRIPTION
Do not emit helper jump if no helper modules are present saving per-every-packet bytecode before ct:
```
inet fw4 prerouting
  [ meta load iifname => reg 1 ]
  [ cmp eq reg 1 0x6c2d7262 0x00006e61 0x00000000 0x00000000 ]
  [ immediate reg 0 jump -> helper_lan ]
  userdata = { \x00-!fw4: Handle lan IPv4/IPv6 helper assignment\x00 }
```